### PR TITLE
ベーシック認証

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production? #本番環境でのみvasic_authが実行される
+  protect_from_forgery with: :exception
+
+  private
+
+  def production? #このメソッドをbefore_actionに記述する
+    Rails.env.production? #現在の環境が本番ならtrue,違えばfalseを返す
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"] #環境変数にして開発、本番環境にvimで定義する
+    end
+  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,9 @@
 server '18.178.72.144', user: 'ec2-user', roles: %w{app db web}
 
+# 本番環境のみでBasic認証ができるようにする 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
+
 # server-based syntax
 # ======================
 # Defines a single server with a list of roles and multiple properties.


### PR DESCRIPTION
#what
ベーシック認証の実装

#why
誤ってアクセスしたユーザーに誤解を生むことがないようにする