### PR TITLE
商品詳細ページ（サーバーサイド画像表示）

### DIFF
--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -31,15 +31,18 @@
   }
   .owl-item {
     height: 60px;
-    width: 60px;
+    width: 100%;
     overflow: hidden;
-    float: left;
-    position: relative;
     cursor: pointer;
-    opacity: 0.4;
-    &:hover{
-      opacity: 1; 
-    }
+  }
+  .sub-image {
+    float: left;
+    display: block;
+    position: relative;
+    opacity: 0.4
+  }
+  .sub-image:hover {
+    opacity: 1;
   }
   table {
     width: 300px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,8 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
+    @images = @item.images.order('id ASC')
   end
 
   def new
@@ -10,4 +12,5 @@ class ItemsController < ApplicationController
 
   def edit
   end
+
 end

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,0 +1,5 @@
+class Brand < ApplicationRecord
+  has_many :items
+
+  validates :name, presence: true
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,6 +3,5 @@ class Image < ApplicationRecord
   # 画像アップロード時に必要な記述
   # mount_uploders :url,ImageUploder 
 
-  validates :url, presence: true
-  validates :item_id, presence: true
+  validates :url,:item_id, presence: true
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,7 @@
+class Image < ApplicationRecord
+  belongs_to :item
+  # mount_uploders :url,ImageUploder
+
+  validates :url, presence: true
+  validates :item_id, presence: true
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,7 @@
 class Image < ApplicationRecord
   belongs_to :item
-  # mount_uploders :url,ImageUploder
+  # 画像アップロード時に必要な記述
+  # mount_uploders :url,ImageUploder 
 
   validates :url, presence: true
   validates :item_id, presence: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,6 +11,7 @@ class Item < ApplicationRecord
   belongs_to :seller, class_name: "User"
   belongs_to :buyer, class_name: "User"
   has_many   :images,dependent: :destroy
+  # 画像のアップロード時に必要な記述
   # accepts_nested_attributes_for :images,allow_destory: true
   has_many :likes
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,4 +8,10 @@ class Item < ApplicationRecord
   belongs_to_active_hash :delivery_method
   # belongs_to user, foreign_key: 'user_id'
   belongs_to :category
+  belongs_to :seller, class_name: "User"
+  belongs_to :buyer, class_name: "User"
+  has_many   :images,dependent: :destroy
+  # accepts_nested_attributes_for :images,allow_destory: true
+  has_many :likes
+
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,7 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :item, counter_cache: :likes_count
+
+  validates :user_id, presence: true
+  validates :item_id, presence: true
+end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -2,6 +2,5 @@ class Like < ApplicationRecord
   belongs_to :user
   belongs_to :item, counter_cache: :likes_count
 
-  validates :user_id, presence: true
-  validates :item_id, presence: true
+  validates :user_id,:item_id, presence: true
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -2,21 +2,14 @@
   = render "items/toppage/header"
   %section.container
     %h1.item-name
-      LAKOLE レザー調巾着バッグ
+      = @item.name
     .item-content
       .item-photo
         .owl-lazy
-          = image_tag('product/bag.jpg',size: '225x300')
+          = image_tag "#{@images[0].url}",size:'225x300',class:'main-image'
         .owl-item
-          = image_tag('product/bag.jpg',size: '60x60')
-        .owl-item
-          = image_tag('product/bag-1.jpg',size: '60x60')
-        .owl-item
-          = image_tag('product/bag-2.jpg',size: '60x60')
-        .owl-item
-          = image_tag('product/bag-3.jpg',size: '60x60')
-        .owl-item
-          = image_tag('product/bag-4.jpg',size: '60x60')
+          - @images.each do |image|
+            = image_tag "#{image.url}",size:'60x60',class:'sub-image'
       %table.item-table
         %tr.item-table__box
           %th.item-table__box__seller 出品者

--- a/db/migrate/20200228112026_create_images.rb
+++ b/db/migrate/20200228112026_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.text :url, null: false
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200301092753_create_brands.rb
+++ b/db/migrate/20200301092753_create_brands.rb
@@ -1,0 +1,8 @@
+class CreateBrands < ActiveRecord::Migration[5.2]
+  def change
+    create_table :brands do |t|
+      t.string :name, null:false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200301100146_create_likes.rb
+++ b/db/migrate/20200301100146_create_likes.rb
@@ -1,0 +1,9 @@
+class CreateLikes < ActiveRecord::Migration[5.2]
+  def change
+    create_table :likes do |t|
+      t.references :user, null:false, foreign_key: true
+      t.references :item, null:false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_25_032302) do
+ActiveRecord::Schema.define(version: 2020_03_01_100146) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
     t.string "city"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -31,6 +37,14 @@ ActiveRecord::Schema.define(version: 2020_02_25_032302) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.text "url", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_images_on_item_id"
   end
 
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -50,6 +64,15 @@ ActiveRecord::Schema.define(version: 2020_02_25_032302) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_likes_on_item_id"
+    t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
   create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "provider"
     t.string "uid"
@@ -66,9 +89,9 @@ ActiveRecord::Schema.define(version: 2020_02_25_032302) do
     t.string "last_name", null: false
     t.string "first_name_kana", null: false
     t.string "last_name_kana", null: false
-    t.integer "birth_year", null: false
-    t.integer "birth_month", null: false
-    t.integer "birth_day", null: false
+    t.date "birth_year", null: false
+    t.date "birth_month", null: false
+    t.date "birth_day", null: false
     t.string "comment"
     t.string "phone_number", null: false
     t.string "encrypted_password", default: "", null: false
@@ -81,5 +104,8 @@ ActiveRecord::Schema.define(version: 2020_02_25_032302) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "images", "items"
+  add_foreign_key "likes", "items"
+  add_foreign_key "likes", "users"
   add_foreign_key "sns_credentials", "users"
 end

--- a/spec/factories/brands.rb
+++ b/spec/factories/brands.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :brand do
+    
+  end
+end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :image do
+    
+  end
+end

--- a/spec/factories/likes.rb
+++ b/spec/factories/likes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :like do
+    
+  end
+end

--- a/spec/models/brand_spec.rb
+++ b/spec/models/brand_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Brand, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Image, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Like, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#what
images・brands・likes モデル・テーブルの作成
投稿した画像データが商品詳細ページで表示されるようにする。（とりあえずメイン画像のみ）

#why
サーバーサイドを実装する際、DBのテーブルからデータを取得する必要があるため、先に必要なテーブルのみ作成した。