### PR TITLE
itemsテーブルの更新

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,7 +33,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit()
+    params.require(:item).permit(:name, :price, :comment, :condition_id, :category_id, :size_id, :delivery_charge_id, :prefecture_id, :delivery_days_id, :delivery_method_id, :brand, images_attributes: [:url, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,7 +1,7 @@
 .signup
   = render 'signups/signup_header'
 .sell__container
-  = form_with model: @item, class:'sell-main__form dropzone', id: "item-doropzone", local: true do |f|
+  = form_for @item, url: items_path, method: :post, class:'sell-main__form dropzone', id: "item-doropzone" do |f|
     .sell__container-head
       %h2 商品の情報を入力
     .sell__container-upload-box 
@@ -26,12 +26,12 @@
         %h3.label
           商品名
           .span 必須  
-        = f.text_field :goods, placeholder: "商品名(必須40文字まで)", class: "input-form"
+        = f.text_field :name, placeholder: "商品名(必須40文字まで)", class: "input-form"
       .goods__container-box
         %h3.label
           商品の説明
           .span 必須
-          = f.text_area :introduction, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）\n2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", maxlength: "1000",class: "goods__description"
+          = f.text_area :comment, placeholder: "商品の説明（必須 1,000文字以内）（色、素材、重さ、定価、注意点など）例）\n2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。", maxlength: "1000",class: "goods__description"
     .sell__container-contents
       .sell__container-l
         %h4.sub-text

--- a/db/migrate/20200225032302_create_categories.rb
+++ b/db/migrate/20200225032302_create_categories.rb
@@ -1,9 +1,0 @@
-class CreateCategories < ActiveRecord::Migration[5.2]
-  def change
-    create_table :categories do |t|
-      t.string :name, null:false
-      
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20200308080053_remove_details_from_items.rb
+++ b/db/migrate/20200308080053_remove_details_from_items.rb
@@ -1,0 +1,11 @@
+class RemoveDetailsFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :state, :integer
+    remove_column :items, :category, :string
+    remove_column :items, :size, :integer
+    remove_column :items, :postage, :string
+    remove_column :items, :region, :string
+    remove_column :items, :shopping_date, :integer
+    remove_column :items, :brand, :integer
+  end
+end

--- a/db/migrate/20200308113720_add_details_to_items.rb
+++ b/db/migrate/20200308113720_add_details_to_items.rb
@@ -1,0 +1,13 @@
+class AddDetailsToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :condition_id, :integer, null: false
+    add_column :items, :category_id, :integer, null: false
+    add_column :items, :size_id, :integer
+    add_column :items, :delivery_charge_id, :integer, null: false
+    add_column :items, :prefecture_id, :integer, null: false
+    add_column :items, :delivery_days_id, :integer, null: false
+    add_column :items, :delivery_method_id, :integer, null: false
+    add_column :items, :likes_count, :integer
+    add_column :items, :brand, :text
+  end
+end

--- a/db/migrate/20200308122507_add_user_to_items.rb
+++ b/db/migrate/20200308122507_add_user_to_items.rb
@@ -1,0 +1,5 @@
+class AddUserToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :user, foreign_key: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_08_064232) do
+ActiveRecord::Schema.define(version: 2020_03_08_122507) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -27,12 +27,6 @@ ActiveRecord::Schema.define(version: 2020_03_08_064232) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
   create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.text "url", null: false
     t.bigint "item_id", null: false
@@ -45,17 +39,21 @@ ActiveRecord::Schema.define(version: 2020_03_08_064232) do
     t.string "name", null: false
     t.integer "price", null: false
     t.string "comment"
-    t.integer "state", null: false
-    t.string "category", null: false
-    t.integer "size"
-    t.string "postage", null: false
-    t.string "region", null: false
-    t.integer "shopping_date", null: false
     t.integer "buyer_id"
     t.integer "seller_id", null: false
-    t.integer "brand"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "condition_id", null: false
+    t.integer "category_id", null: false
+    t.integer "size_id"
+    t.integer "delivery_charge_id", null: false
+    t.integer "prefecture_id", null: false
+    t.integer "delivery_days_id", null: false
+    t.integer "delivery_method_id", null: false
+    t.integer "likes_count"
+    t.text "brand"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -99,6 +97,7 @@ ActiveRecord::Schema.define(version: 2020_03_08_064232) do
   end
 
   add_foreign_key "images", "items"
+  add_foreign_key "items", "users"
   add_foreign_key "likes", "items"
   add_foreign_key "likes", "users"
   add_foreign_key "sns_credentials", "users"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,5 +1,0 @@
-FactoryBot.define do
-  factory :category do
-    
-  end
-end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
#what
itemsテーブルの更新
不要なテーブルを削除

#why
itemsテーブルのカラムをactive_hashから外部キーをとる必要があるため
items_controllerの未記入だった部分をカラムができたため追記

不要なテーブルは削除しました